### PR TITLE
Ignore purge of argocd

### DIFF
--- a/applications.d/gha-runner-scale-set-controller/values.yaml
+++ b/applications.d/gha-runner-scale-set-controller/values.yaml
@@ -1,1 +1,3 @@
-
+flags:
+    excludeLabelPropagationPrefixes:
+    - "argocd.argoproj.io/instance"

--- a/applications.d/gha-runner-scale-set/applicationset.yaml
+++ b/applications.d/gha-runner-scale-set/applicationset.yaml
@@ -48,6 +48,3 @@ spec:
         syncOptions:
           - CreateNamespace=true
           - ServerSideApply=true
-      ignoreDifferences:
-      - group: 'cilium.io'
-        kind: CiliumIdentity

--- a/applications.d/gha-runner-scale-set/values.yaml
+++ b/applications.d/gha-runner-scale-set/values.yaml
@@ -7,23 +7,23 @@ global:
   environment: stg
   externalSecret:
     path: bastet-cat/arc-system
-  extraAnnotations:
-    argocd.argoproj.io/compare-options: IgnoreExtraneous
+  extraAnnotations: {}
   extraLabels: {}
   flavours:
     - name: small
       cpu: 1
       memory: 1Gi
-      minRunners: 1
       maxRunners: 3
     - name: medium
       cpu: 3
       memory: 5Gi
+      minRunners: 1
     - name: demo-repository
       cpu: 3
       memory: 5Gi
       repository: demo-repository
   githubConfigUrl: "https://github.com/bastet-cat"
+  minRunners: 0
   maxRunners: 5
   org: my-org
   template:
@@ -41,9 +41,6 @@ global:
             - name: dind-sock
               mountPath: /var/run
   listenerTemplate:
-    metadata:
-      annotations:
-        argocd.argoproj.io/sync-options: Prune=false
     spec:
       containers:
       - name: listener

--- a/assets/gha-runners/helm/values.yaml
+++ b/assets/gha-runners/helm/values.yaml
@@ -7,8 +7,7 @@ global:
   environment: stg
   externalSecret:
     path: my-org/arc-system
-  extraAnnotations:
-    argocd.argoproj.io/compare-options: IgnoreExtraneous
+  extraAnnotations: {}
   extraLabels: {}
   flavours:
     - name: small


### PR DESCRIPTION
This pull request includes changes to ignore the purge of argocd. The `flags` section has been updated to exclude the label propagation prefixes for `argocd.argoproj.io/instance`. Additionally, the `ignoreDifferences` section has been removed from the `spec` section. The `extraAnnotations` and `listenerTemplate` sections have also been modified to remove unnecessary configurations.